### PR TITLE
Positioning improvements and option to disable viewer code

### DIFF
--- a/src/main/java/com/nodiumhosting/vaultmapper/config/ClientConfig.java
+++ b/src/main/java/com/nodiumhosting/vaultmapper/config/ClientConfig.java
@@ -29,6 +29,7 @@ public class ClientConfig {
     public static final ForgeConfigSpec.ConfigValue<Boolean> SYNC_ENABLED;
     public static final ForgeConfigSpec.ConfigValue<String> VMSYNC_SERVER;
     public static final ForgeConfigSpec.ConfigValue<String> SYNC_COLOR;
+    public static final ForgeConfigSpec.ConfigValue<Boolean> SHOW_VIEWER_CODE;
 
     public static final ForgeConfigSpec.ConfigValue<Integer> PC_CUTOFF;
     public static final ForgeConfigSpec.ConfigValue<Boolean> PC_BORDER;
@@ -74,6 +75,8 @@ public class ClientConfig {
         VMSYNC_SERVER = BUILDER.comment("The IP of the Vault Mapper Sync Server to sync through").define("VMSYNC_SERVER", "wss://vmsync.ndmh.xyz");
 
         SYNC_COLOR = BUILDER.comment("Your color for other players in the vault").define("SYNC_COLOR", "random");
+
+        SHOW_VIEWER_CODE = BUILDER.comment("Show viewer code below the vault map").define("SHOW_VIEWER_CODE", false);
 
         PC_CUTOFF = BUILDER.comment("Number of cells rendered around player").define("PC_CUTOFF", 20);
         PC_BORDER = BUILDER.comment("Render border around the player centric rendering range").define("PC_BORDER", true);

--- a/src/main/java/com/nodiumhosting/vaultmapper/events/KeybindEvents.java
+++ b/src/main/java/com/nodiumhosting/vaultmapper/events/KeybindEvents.java
@@ -1,6 +1,7 @@
 package com.nodiumhosting.vaultmapper.events;
 
 import com.nodiumhosting.vaultmapper.VaultMapper;
+import com.nodiumhosting.vaultmapper.config.ClientConfig;
 import com.nodiumhosting.vaultmapper.gui.screen.VaultMapperConfigScreen;
 import com.nodiumhosting.vaultmapper.map.VaultMap;
 import net.minecraft.client.KeyMapping;
@@ -21,12 +22,14 @@ public class KeybindEvents {
     public static KeyMapping openConfigKey;
     public static KeyMapping syncReconnectKey;
     public static KeyMapping toggleMapKey;
+    public static KeyMapping toggleViewerCode;
 
     public static void registerKeyBinds() {
         markKey = registerKeyMapping("mark", GLFW.GLFW_KEY_MINUS);
         openConfigKey = registerKeyMapping("openconfig", GLFW.GLFW_KEY_F7);
         syncReconnectKey = registerKeyMapping("reconnectsync", GLFW.GLFW_KEY_UNKNOWN);
         toggleMapKey = registerKeyMapping("togglemap", GLFW.GLFW_KEY_EQUAL);
+        toggleViewerCode = registerKeyMapping("toggleviewercode", GLFW.GLFW_KEY_UNKNOWN);
     }
 
     // Helper method to register KeyMappings
@@ -64,6 +67,11 @@ public class KeybindEvents {
         // Toggle rendering of the VaultMap
         if(toggleMapKey.consumeClick()) {
             VaultMap.toggleRendering();
+        }
+
+        // Toggle rendering of the viewer code
+        if(toggleViewerCode.consumeClick()) {
+            ClientConfig.SHOW_VIEWER_CODE.set(!ClientConfig.SHOW_VIEWER_CODE.get());
         }
     }
 }

--- a/src/main/java/com/nodiumhosting/vaultmapper/gui/screen/VaultMapperConfigScreen.java
+++ b/src/main/java/com/nodiumhosting/vaultmapper/gui/screen/VaultMapperConfigScreen.java
@@ -91,23 +91,23 @@ public class VaultMapperConfigScreen extends Screen {
         Slider PCCutoff = new Slider(this.width / 2 + 10, getScaledY(4), "", ClientConfig.PC_CUTOFF.get(), 30, 4, PCCutoffGetter, width, elHeight, 20);
         this.addRenderableWidget(PCCutoff);
 
-        MutableComponent enabledTextBorder = new TextComponent("✔").withStyle(ChatFormatting.BOLD, ChatFormatting.GREEN);
-        MutableComponent disabledTextBorder = new TextComponent("❌").withStyle(ChatFormatting.BOLD, ChatFormatting.RED);
+        MutableComponent enabledText = new TextComponent("✔").withStyle(ChatFormatting.BOLD, ChatFormatting.GREEN);
+        MutableComponent disabledText = new TextComponent("❌").withStyle(ChatFormatting.BOLD, ChatFormatting.RED);
 
-        Button playerCentric = new Button(this.width / 2 + width + 15, getScaledY(4), elHeight, Math.min(elHeight, 20),  ClientConfig.PLAYER_CENTRIC_RENDERING.get() ? enabledTextBorder : disabledTextBorder, button -> {
+        Button playerCentric = new Button(this.width / 2 + width + 15, getScaledY(4), elHeight, Math.min(elHeight, 20),  ClientConfig.PLAYER_CENTRIC_RENDERING.get() ? enabledText : disabledText, button -> {
             ClientConfig.PLAYER_CENTRIC_RENDERING.set(!ClientConfig.PLAYER_CENTRIC_RENDERING.get());
             ClientConfig.SPEC.save();
-            button.setMessage(ClientConfig.PLAYER_CENTRIC_RENDERING.get() ? enabledTextBorder : disabledTextBorder);
+            button.setMessage(ClientConfig.PLAYER_CENTRIC_RENDERING.get() ? enabledText : disabledText);
             },
             (pButton, pPoseStack, pMouseX, pMouseY) -> {
                 renderTooltip(pPoseStack, new TextComponent("Player Centric Rendering"), pMouseX, pMouseY);
             });
         this.addRenderableWidget(playerCentric);
 
-        Button enablePCBorderButton = new Button(this.width / 2 + width + 15 + 2 + elHeight, getScaledY(4), elHeight, Math.min(elHeight, 20), ClientConfig.SYNC_ENABLED.get() ? enabledTextBorder : disabledTextBorder, button -> {
+        Button enablePCBorderButton = new Button(this.width / 2 + width + 15 + 2 + elHeight, getScaledY(4), elHeight, Math.min(elHeight, 20), ClientConfig.SYNC_ENABLED.get() ? enabledText : disabledText, button -> {
             ClientConfig.PC_BORDER.set(!ClientConfig.PC_BORDER.get());
             ClientConfig.SPEC.save();
-            button.setMessage(ClientConfig.PC_BORDER.get() ? enabledTextBorder : disabledTextBorder);
+            button.setMessage(ClientConfig.PC_BORDER.get() ? enabledText : disabledText);
             },
             (pButton, pPoseStack, pMouseX, pMouseY) -> {
                 renderTooltip(pPoseStack, new TextComponent("Player Centric Border"), pMouseX, pMouseY);
@@ -220,10 +220,10 @@ public class VaultMapperConfigScreen extends Screen {
         inscriptionRoomColor.setResponder((value) -> {
             inscriptionRoomColorPicker.setColor(parseColor(value));
         });
-        Button showInscription = new Button(this.width / 2 + elWidthColor + 5 + 10 + elHeight + 5 - 2, getScaledY(13), elHeight, Math.min(elHeight, 20),  ClientConfig.SHOW_INSCRIPTIONS.get() ? enabledTextBorder : disabledTextBorder, button -> {
+        Button showInscription = new Button(this.width / 2 + elWidthColor + 5 + 10 + elHeight + 5 - 2, getScaledY(13), elHeight, Math.min(elHeight, 20),  ClientConfig.SHOW_INSCRIPTIONS.get() ? enabledText : disabledText, button -> {
             ClientConfig.SHOW_INSCRIPTIONS.set(!ClientConfig.SHOW_INSCRIPTIONS.get());
             ClientConfig.SPEC.save();
-            button.setMessage(ClientConfig.SHOW_INSCRIPTIONS.get() ? enabledTextBorder : disabledTextBorder);
+            button.setMessage(ClientConfig.SHOW_INSCRIPTIONS.get() ? enabledText : disabledText);
         },
             (pButton, pPoseStack, pMouseX, pMouseY) -> {
                 renderTooltip(pPoseStack, new TextComponent("Show Inscriptions"), pMouseX, pMouseY);
@@ -263,10 +263,10 @@ public class VaultMapperConfigScreen extends Screen {
             oreRoomColorPicker.setColor(parseColor(value));
         });
 
-        Button showRoomIcons = new Button(this.width / 2 + elWidthColor + 5 + 10 + elHeight + 5 - 2, getScaledY(14), elHeight, Math.min(elHeight, 20),  ClientConfig.SHOW_ROOM_ICONS.get() ? enabledTextBorder : disabledTextBorder, button -> {
+        Button showRoomIcons = new Button(this.width / 2 + elWidthColor + 5 + 10 + elHeight + 5 - 2, getScaledY(14), elHeight, Math.min(elHeight, 20),  ClientConfig.SHOW_ROOM_ICONS.get() ? enabledText : disabledText, button -> {
             ClientConfig.SHOW_ROOM_ICONS.set(!ClientConfig.SHOW_ROOM_ICONS.get());
             ClientConfig.SPEC.save();
-            button.setMessage(ClientConfig.SHOW_ROOM_ICONS.get() ? enabledTextBorder : disabledTextBorder);
+            button.setMessage(ClientConfig.SHOW_ROOM_ICONS.get() ? enabledText : disabledText);
             },
             (pButton, pPoseStack, pMouseX, pMouseY) -> {
                 renderTooltip(pPoseStack, new TextComponent("Room Icons"), pMouseX, pMouseY);
@@ -276,8 +276,7 @@ public class VaultMapperConfigScreen extends Screen {
         EditBoxReset syncServer = new EditBoxReset(this.font, this.width / 2 - 70, getScaledY(17), elWidthColor + 80, elHeight, new TextComponent("SYNC_SERVER"), "wss://vmsync.ndmh.xyz");
         syncServer.setValue(ClientConfig.VMSYNC_SERVER.get());
         this.addRenderableWidget(syncServer);
-        MutableComponent enabledText = new TextComponent("✔").withStyle(ChatFormatting.BOLD, ChatFormatting.GREEN);
-        MutableComponent disabledText = new TextComponent("❌").withStyle(ChatFormatting.BOLD, ChatFormatting.RED);
+
         Button enableSyncButton = new Button(this.width / 2 + elWidthColor + 5 + 10, getScaledY(17), elHeight, elHeight, ClientConfig.SYNC_ENABLED.get() ? enabledText : disabledText, button -> {
             ClientConfig.SYNC_ENABLED.set(!ClientConfig.SYNC_ENABLED.get());
             ClientConfig.SPEC.save();
@@ -357,22 +356,22 @@ public class VaultMapperConfigScreen extends Screen {
             startRoomColor.setValue("#FF0000");
             markedRoomColor.setValue("#FF00FF");
             inscriptionRoomColor.setValue("#FFFF00");
-            enableSyncButton.setMessage(enabledText);
+            showRoomIcons.setMessage(enabledText);
 
             omegaRoomColor.setValue("#55FF55");
             challengeRoomColor.setValue("#F09E00");
             oreRoomColor.setValue("#00FFFF");
             showInscription.setMessage(enabledText);
             syncServer.setValue("wss://vmsync.ndmh.xyz");
-            enableSyncButton.setMessage(disabledText);
-
+            enableSyncButton.setMessage(enabledText);
+            showViewerCodeButton.setMessage(disabledText);
             String randColor = Util.RandomColor();
 
             syncColor.setValue(randColor);
 
             PCCutoff.sliderValue = 20;
-            enableSyncButton.setMessage(enabledText);
-            enablePCBorderButton.setMessage(disabledTextBorder);
+            playerCentric.setMessage(disabledText);
+            enablePCBorderButton.setMessage(enabledText);
 
             ClientConfig.MAP_SCALE.set(10);
             ClientConfig.MAP_X_OFFSET.set(0);
@@ -392,6 +391,7 @@ public class VaultMapperConfigScreen extends Screen {
             ClientConfig.VMSYNC_SERVER.set("wss://vmsync.ndmh.xyz");
             ClientConfig.SYNC_ENABLED.set(true);
             ClientConfig.SYNC_COLOR.set(randColor);
+            ClientConfig.SHOW_VIEWER_CODE.set(false);
 
             ClientConfig.PC_CUTOFF.set(20);
             ClientConfig.PLAYER_CENTRIC_RENDERING.set(false);

--- a/src/main/java/com/nodiumhosting/vaultmapper/gui/screen/VaultMapperConfigScreen.java
+++ b/src/main/java/com/nodiumhosting/vaultmapper/gui/screen/VaultMapperConfigScreen.java
@@ -12,7 +12,6 @@ import it.unimi.dsi.fastutil.Function;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.components.Button;
-import net.minecraft.client.gui.components.Checkbox;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.TextComponent;
@@ -92,16 +91,27 @@ public class VaultMapperConfigScreen extends Screen {
         Slider PCCutoff = new Slider(this.width / 2 + 10, getScaledY(4), "", ClientConfig.PC_CUTOFF.get(), 30, 4, PCCutoffGetter, width, elHeight, 20);
         this.addRenderableWidget(PCCutoff);
 
-        Checkbox playerCentric = new Checkbox(this.width / 2 + elWidthColor + 5 + 10 + elHeight + 5 - 2, getScaledY(4) - 3, 20, 20, new TextComponent(""), ClientConfig.PLAYER_CENTRIC_RENDERING.get());
-        this.addRenderableWidget(playerCentric);
-
         MutableComponent enabledTextBorder = new TextComponent("✔").withStyle(ChatFormatting.BOLD, ChatFormatting.GREEN);
         MutableComponent disabledTextBorder = new TextComponent("❌").withStyle(ChatFormatting.BOLD, ChatFormatting.RED);
-        Button enablePCBorderButton = new Button(this.width / 2 + elWidthColor + 5 + 10 + elHeight + 5 - 2 + 20 + 5, getScaledY(4), elHeight, elHeight, ClientConfig.SYNC_ENABLED.get() ? enabledTextBorder : disabledTextBorder, button -> {
+
+        Button playerCentric = new Button(this.width / 2 + width + 15, getScaledY(4), elHeight, Math.min(elHeight, 20),  ClientConfig.PLAYER_CENTRIC_RENDERING.get() ? enabledTextBorder : disabledTextBorder, button -> {
+            ClientConfig.PLAYER_CENTRIC_RENDERING.set(!ClientConfig.PLAYER_CENTRIC_RENDERING.get());
+            ClientConfig.SPEC.save();
+            button.setMessage(ClientConfig.PLAYER_CENTRIC_RENDERING.get() ? enabledTextBorder : disabledTextBorder);
+            },
+            (pButton, pPoseStack, pMouseX, pMouseY) -> {
+                renderTooltip(pPoseStack, new TextComponent("Player Centric Rendering"), pMouseX, pMouseY);
+            });
+        this.addRenderableWidget(playerCentric);
+
+        Button enablePCBorderButton = new Button(this.width / 2 + width + 15 + 2 + elHeight, getScaledY(4), elHeight, Math.min(elHeight, 20), ClientConfig.SYNC_ENABLED.get() ? enabledTextBorder : disabledTextBorder, button -> {
             ClientConfig.PC_BORDER.set(!ClientConfig.PC_BORDER.get());
             ClientConfig.SPEC.save();
             button.setMessage(ClientConfig.PC_BORDER.get() ? enabledTextBorder : disabledTextBorder);
-        });
+            },
+            (pButton, pPoseStack, pMouseX, pMouseY) -> {
+                renderTooltip(pPoseStack, new TextComponent("Player Centric Border"), pMouseX, pMouseY);
+            });
         this.addRenderableWidget(enablePCBorderButton);
 
         EditBoxReset mapXOffset = new EditBoxReset(this.font, this.width / 2 + 10, getScaledY(5), width, elHeight, new TextComponent("MAP_X_OFFSET"), "0");
@@ -210,7 +220,14 @@ public class VaultMapperConfigScreen extends Screen {
         inscriptionRoomColor.setResponder((value) -> {
             inscriptionRoomColorPicker.setColor(parseColor(value));
         });
-        Checkbox showInscription = new Checkbox(this.width / 2 + elWidthColor + 5 + 10 + elHeight + 5 - 2, getScaledY(13) - 3, 20, 20, new TextComponent(""), ClientConfig.SHOW_INSCRIPTIONS.get());
+        Button showInscription = new Button(this.width / 2 + elWidthColor + 5 + 10 + elHeight + 5 - 2, getScaledY(13), elHeight, Math.min(elHeight, 20),  ClientConfig.SHOW_INSCRIPTIONS.get() ? enabledTextBorder : disabledTextBorder, button -> {
+            ClientConfig.SHOW_INSCRIPTIONS.set(!ClientConfig.SHOW_INSCRIPTIONS.get());
+            ClientConfig.SPEC.save();
+            button.setMessage(ClientConfig.SHOW_INSCRIPTIONS.get() ? enabledTextBorder : disabledTextBorder);
+        },
+            (pButton, pPoseStack, pMouseX, pMouseY) -> {
+                renderTooltip(pPoseStack, new TextComponent("Show Inscriptions"), pMouseX, pMouseY);
+            });
         this.addRenderableWidget(showInscription);
 
         EditBoxReset omegaRoomColor = new EditBoxReset(this.font, this.width / 2 + 10, getScaledY(14), elWidthColor, elHeight, new TextComponent("OMEGA_ROOM_COLOR"), "#55FF55");
@@ -246,8 +263,14 @@ public class VaultMapperConfigScreen extends Screen {
             oreRoomColorPicker.setColor(parseColor(value));
         });
 
-        int roomIconsCheckboxY = getScaledY(14) + (getScaledY(1) / 2) - 2;
-        Checkbox showRoomIcons = new Checkbox(this.width / 2 + elWidthColor + 5 + 10 + elHeight + 5 - 2, roomIconsCheckboxY, 20, 20, new TextComponent(""), ClientConfig.SHOW_ROOM_ICONS.get());
+        Button showRoomIcons = new Button(this.width / 2 + elWidthColor + 5 + 10 + elHeight + 5 - 2, getScaledY(14), elHeight, Math.min(elHeight, 20),  ClientConfig.SHOW_ROOM_ICONS.get() ? enabledTextBorder : disabledTextBorder, button -> {
+            ClientConfig.SHOW_ROOM_ICONS.set(!ClientConfig.SHOW_ROOM_ICONS.get());
+            ClientConfig.SPEC.save();
+            button.setMessage(ClientConfig.SHOW_ROOM_ICONS.get() ? enabledTextBorder : disabledTextBorder);
+            },
+            (pButton, pPoseStack, pMouseX, pMouseY) -> {
+                renderTooltip(pPoseStack, new TextComponent("Room Icons"), pMouseX, pMouseY);
+            });
         this.addRenderableWidget(showRoomIcons);
 
         EditBoxReset syncServer = new EditBoxReset(this.font, this.width / 2 - 70, getScaledY(17), elWidthColor + 80, elHeight, new TextComponent("SYNC_SERVER"), "wss://vmsync.ndmh.xyz");
@@ -259,8 +282,21 @@ public class VaultMapperConfigScreen extends Screen {
             ClientConfig.SYNC_ENABLED.set(!ClientConfig.SYNC_ENABLED.get());
             ClientConfig.SPEC.save();
             button.setMessage(ClientConfig.SYNC_ENABLED.get() ? enabledText : disabledText);
-        });
+            },
+            (pButton, pPoseStack, pMouseX, pMouseY) -> {
+                renderTooltip(pPoseStack, new TextComponent("Sync"), pMouseX, pMouseY);
+            });
         this.addRenderableWidget(enableSyncButton);
+
+        Button showViewerCodeButton = new Button(this.width / 2 + elWidthColor + 5 + 10 + elHeight + 5, getScaledY(17), elHeight, elHeight, ClientConfig.SHOW_VIEWER_CODE.get() ? enabledText : disabledText, button -> {
+            ClientConfig.SHOW_VIEWER_CODE.set(!ClientConfig.SHOW_VIEWER_CODE.get());
+            ClientConfig.SPEC.save();
+            button.setMessage(ClientConfig.SHOW_VIEWER_CODE.get() ? enabledText : disabledText);
+        },
+            (pButton, pPoseStack, pMouseX, pMouseY) -> {
+                renderTooltip(pPoseStack, new TextComponent("Show Viewer Code"), pMouseX, pMouseY);
+            });
+        this.addRenderableWidget(showViewerCodeButton);
 
         EditBoxReset syncColor = new EditBoxReset(this.font, this.width / 2 + 10, getScaledY(18), elWidthColor, elHeight, new TextComponent("SYNC_COLOR"), Util.RandomColor());
         syncColor.setValue(ClientConfig.SYNC_COLOR.get());
@@ -294,17 +330,13 @@ public class VaultMapperConfigScreen extends Screen {
             ClientConfig.START_ROOM_COLOR.set(startRoomColor.getValue());
             ClientConfig.MARKED_ROOM_COLOR.set(markedRoomColor.getValue());
             ClientConfig.INSCRIPTION_ROOM_COLOR.set(inscriptionRoomColor.getValue());
-            ClientConfig.SHOW_INSCRIPTIONS.set(showInscription.selected());
             ClientConfig.OMEGA_ROOM_COLOR.set(omegaRoomColor.getValue());
             ClientConfig.CHALLENGE_ROOM_COLOR.set(challengeRoomColor.getValue());
             ClientConfig.ORE_ROOM_COLOR.set(oreRoomColor.getValue());
-            ClientConfig.SHOW_ROOM_ICONS.set(showRoomIcons.selected());
             ClientConfig.VMSYNC_SERVER.set(syncServer.getValue());
             ClientConfig.SYNC_COLOR.set(syncColor.getValue());
 
             ClientConfig.PC_CUTOFF.set(PCCutoff.sliderValue);
-            ClientConfig.PLAYER_CENTRIC_RENDERING.set(playerCentric.selected());
-
             ClientConfig.SPEC.save();
 
             VaultMapOverlayRenderer.prep();
@@ -325,26 +357,21 @@ public class VaultMapperConfigScreen extends Screen {
             startRoomColor.setValue("#FF0000");
             markedRoomColor.setValue("#FF00FF");
             inscriptionRoomColor.setValue("#FFFF00");
-            if (!showInscription.selected()) {
-                showInscription.onPress();
-            }
+            enableSyncButton.setMessage(enabledText);
+
             omegaRoomColor.setValue("#55FF55");
             challengeRoomColor.setValue("#F09E00");
             oreRoomColor.setValue("#00FFFF");
-            if (!showRoomIcons.selected()) {
-                showRoomIcons.onPress();
-            }
+            showInscription.setMessage(enabledText);
             syncServer.setValue("wss://vmsync.ndmh.xyz");
-            enableSyncButton.setMessage(enabledText);
+            enableSyncButton.setMessage(disabledText);
 
             String randColor = Util.RandomColor();
 
             syncColor.setValue(randColor);
 
             PCCutoff.sliderValue = 20;
-            if (!playerCentric.selected()) {
-                playerCentric.onPress();
-            }
+            enableSyncButton.setMessage(enabledText);
             enablePCBorderButton.setMessage(disabledTextBorder);
 
             ClientConfig.MAP_SCALE.set(10);

--- a/src/main/java/com/nodiumhosting/vaultmapper/map/VaultMap.java
+++ b/src/main/java/com/nodiumhosting/vaultmapper/map/VaultMap.java
@@ -50,10 +50,11 @@ public class VaultMap {
     public static CopyOnWriteArrayList<VaultCell> cells = new CopyOnWriteArrayList<>();
     static VaultCell startRoom = new VaultCell(0, 0, CellType.CELLTYPE_ROOM, RoomType.ROOMTYPE_START);
     static VaultCell currentRoom; // might not be needed
-    static int defaultMapSize = 21; // map size in cells
-    static int defaultCoordLimit = 10; // limit for coords, so a cell at -6 on x or z would be considered out of bounds and trigger action
-    static int currentMapSize = defaultMapSize;
-    static int currentCoordLimit = defaultCoordLimit; // initialize to default values, will change and reset
+    static int defaultMapSize = 10; // map size in cells
+    static int northSize = defaultMapSize;
+    static int eastSize = defaultMapSize;
+    static int southSize = defaultMapSize;
+    static int westSize = defaultMapSize;
     static CompoundTag hologramData;
     static boolean hologramChecked;
     // TODO: do this properly
@@ -117,8 +118,10 @@ public class VaultMap {
         hologramChecked = false;
         hologramData = null;
 
-        currentMapSize = defaultMapSize;
-        currentCoordLimit = defaultCoordLimit;
+        northSize = defaultMapSize;
+        eastSize = defaultMapSize;
+        southSize = defaultMapSize;
+        westSize = defaultMapSize;
 
         VaultMapper.webMapServer.sendReset();
     }
@@ -213,11 +216,19 @@ public class VaultMap {
     public static void addOrReplaceCell(VaultCell cell) {
         cells.removeIf((c) -> c.x == cell.x && c.z == cell.z);
         cells.add(cell);
-        if (abs(cell.x) > currentCoordLimit || abs(cell.z) > currentCoordLimit) { // resize map
-            currentMapSize += 4;
-            currentCoordLimit += 2;
-            VaultMapOverlayRenderer.updateAnchor();
+        if (cell.x > eastSize){
+            eastSize = cell.x;
         }
+        if (cell.x < 0 && abs(cell.x) > westSize){
+            westSize = abs(cell.x);
+        }
+        if (cell.z > southSize){
+            southSize = cell.z;
+        }
+        if (cell.z < 0 && abs(cell.z) > northSize ){
+            northSize = abs(cell.z);
+        }
+        VaultMapOverlayRenderer.updateAnchor();
     }
 
     /**
@@ -253,14 +264,7 @@ public class VaultMap {
         if (playerRoomX == 0 && playerRoomZ == 0) {
             newCell.roomType = RoomType.ROOMTYPE_START;
         }
-
         if (isNewCell(newCell, cells)) {
-            if (abs(currentRoom.x) > currentCoordLimit || abs(currentRoom.z) > currentCoordLimit) { // resize map
-                currentMapSize += 4;
-                currentCoordLimit += 2;
-                VaultMapOverlayRenderer.updateAnchor();
-            }
-
             if (cellType != CellType.CELLTYPE_UNKNOWN) {
                 if (!(playerRoomX == 0 && playerRoomZ == 0)) { //dont detect start room
                     if (cellType == CellType.CELLTYPE_ROOM) {

--- a/src/main/java/com/nodiumhosting/vaultmapper/map/VaultMapOverlayRenderer.java
+++ b/src/main/java/com/nodiumhosting/vaultmapper/map/VaultMapOverlayRenderer.java
@@ -59,25 +59,16 @@ public class VaultMapOverlayRenderer {
             playerX = 0;
             playerZ = 0;
         }
-
         if (syncErrorState) {
-            int w = Minecraft.getInstance().getWindow().getGuiScaledWidth();
-            int mapSize = (int) (w * 0.25f);
-            int baseMapRoomWidth = mapSize / 49;
-            int offset = baseMapRoomWidth * VaultMap.currentMapSize / 2;
-
+            float offset = playerCentricRender ?  (cutoff + 1) * mapRoomWidth : (VaultMap.northSize + 1) * mapRoomWidth;
             TextComponent syncError = new TextComponent("Sync Error");
-            GuiComponent.drawCenteredString(event.getMatrixStack(), Minecraft.getInstance().font, syncError, (int) centerX, (int) mapAnchorZ - offset - 10, 0xFFFFFF);
+            GuiComponent.drawCenteredString(event.getMatrixStack(), Minecraft.getInstance().font, syncError, (int) centerX, (int) mapAnchorZ - (int) offset - 9, 0xFFFFFF);
         }
 
-        if (VaultMap.viewerCode != null) {
-            int w = Minecraft.getInstance().getWindow().getGuiScaledWidth();
-            int mapSize = (int) (w * 0.25f);
-            int baseMapRoomWidth = mapSize / 49;
-            int offset = baseMapRoomWidth * VaultMap.currentMapSize / 2;
-
+        if (VaultMap.viewerCode != null && ClientConfig.SHOW_VIEWER_CODE.get()) {
+            float offset = playerCentricRender ? (cutoff + 1) * mapRoomWidth : (VaultMap.southSize + 1) * mapRoomWidth;
             TextComponent syncError = new TextComponent(VaultMap.viewerCode);
-            GuiComponent.drawCenteredString(event.getMatrixStack(), Minecraft.getInstance().font, syncError, (int) centerX, (int) mapAnchorZ + offset + 10, 0xFFFFFF);
+            GuiComponent.drawCenteredString(event.getMatrixStack(), Minecraft.getInstance().font, syncError, (int) centerX, (int) mapAnchorZ + (int) offset, 0xFFFFFF);
         }
 
         BufferBuilder bufferBuilder = Tesselator.getInstance().getBuilder();
@@ -446,11 +437,14 @@ public class VaultMapOverlayRenderer {
         int width = Minecraft.getInstance().getWindow().getGuiScaledWidth();
         int height = Minecraft.getInstance().getWindow().getGuiScaledHeight();
 
-        float mapSize = (VaultMap.currentMapSize * mapRoomWidth);
-
+        int sideMargin = 2*(int)mapRoomWidth + Minecraft.getInstance().font.lineHeight;
         switch (ClientConfig.MAP_X_ANCHOR.get()) {
             case 0 -> {
-                mapAnchorX = (mapSize / 2) + 20;
+                if (playerCentricRender){
+                    mapAnchorX = mapRoomWidth * cutoff + sideMargin;
+                } else {
+                    mapAnchorX = VaultMap.westSize * mapRoomWidth + mapRoomWidth + sideMargin;
+                }
             }
             case 1 -> {
                 mapAnchorX = (float) width / 4;
@@ -462,13 +456,21 @@ public class VaultMapOverlayRenderer {
                 mapAnchorX = width - ((float) width / 4);
             }
             case 4 -> {
-                mapAnchorX = width - (mapSize / 2) - 20;
+                if (playerCentricRender){
+                    mapAnchorX = width - mapRoomWidth * cutoff - sideMargin;
+                } else {
+                    mapAnchorX = width - VaultMap.eastSize * mapRoomWidth + mapRoomWidth - sideMargin;
+                }
             }
         }
 
         switch (ClientConfig.MAP_Y_ANCHOR.get()) {
             case 0 -> {
-                mapAnchorZ = (mapSize / 2) + 20;
+                if (playerCentricRender){
+                    mapAnchorZ = mapRoomWidth * cutoff + sideMargin;
+                } else {
+                    mapAnchorZ = VaultMap.northSize * mapRoomWidth + mapRoomWidth + sideMargin;
+                }
             }
             case 1 -> {
                 mapAnchorZ = (float) height / 4;
@@ -480,7 +482,11 @@ public class VaultMapOverlayRenderer {
                 mapAnchorZ = height - ((float) height / 4);
             }
             case 4 -> {
-                mapAnchorZ = height - (mapSize / 2) - 20;
+                if (playerCentricRender){
+                    mapAnchorZ = height - mapRoomWidth * cutoff - sideMargin;
+                } else {
+                    mapAnchorZ = height - VaultMap.southSize * mapRoomWidth + mapRoomWidth - sideMargin;
+                }
             }
         }
 

--- a/src/main/resources/assets/vaultmapper/lang/en_us.json
+++ b/src/main/resources/assets/vaultmapper/lang/en_us.json
@@ -3,5 +3,6 @@
   "key.vaultmapper.togglemap": "Toggle Vault Map",
   "key.vaultmapper.openconfig": "Open Config Screen",
   "key.vaultmapper.reconnectsync": "Restart VMSync (Debug)",
+  "key.vaultmapper.toggleviewercode": "Toggle Viewer Code",
   "key.categories.vaultmapper": "Vault Mapper"
 }


### PR DESCRIPTION
Side positions now only consider width of relevant sides (north for top pos, east for right) instead of the longest side
Viewer code and sync error msg is now in correct position for most gui scale/map scale combinations, with and without player centric rendering
Disabled viewer code by default and added option to enable it from config/with keybind
Replaced mojank checkboxes with buttons that scale and added tooltips to them

top-right before:
![2025-02-12_20 38 24](https://github.com/user-attachments/assets/93197110-5e98-44bb-83d6-61bce6dcf7a2)

top-right after:
![2025-02-12_20 44 48](https://github.com/user-attachments/assets/0366ae86-7a7c-425e-a8c1-71067ee63a74)

new config buttons with tooltips (it's yellow because it's wold's):
![2025-02-12_20 46 19](https://github.com/user-attachments/assets/0a1b8812-85f0-4b4d-bc3f-ffc55085ba98)
